### PR TITLE
Readme update along side with new cpu-aware CGroup normalized metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# clickhouse-mixin
+# ClickHouse Cloud Prometheus/Grafana mix-in
+
+Pre-configured Grafana dashboard for monitoring ClickHouse Cloud services via the ClickHouse Cloud
+[Prometheus API endpoint](https://clickhouse.com/docs/integrations/prometheus).
+
+It also supports
+[native ClickHouse Prometheus exporter](https://clickhouse.com/docs/operations/server-configuration-parameters/settings#prometheus).
+
+## Links
+- Dashboard in [Grafana dashboards marketplace](https://grafana.com/grafana/dashboards/23415-prom-exporter-instance-dashboard-v2/)
+- Getting started guide in our [blog post](https://clickhouse.com/blog/monitor-with-new-prometheus-grafana-mix-in)

--- a/dashboard.json
+++ b/dashboard.json
@@ -910,7 +910,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "(ClickHouseAsyncMetrics_OSUserTimeNormalized{\n    clickhouse_service=\"$service_id\",\n}\n+\nClickHouseAsyncMetrics_OSSystemTimeNormalized{\n    clickhouse_service=\"$service_id\",\n}) * 100",
+          "expr": "(ClickHouseAsyncMetrics_CGroupUserTimeNormalized{\n    clickhouse_service=\"$service_id\",\n}\n+\nClickHouseAsyncMetrics_CGroupSystemTimeNormalized{\n    clickhouse_service=\"$service_id\",\n}) * 100",
           "format": "time_series",
           "instant": false,
           "legendFormat": "{{instance}}",
@@ -1526,7 +1526,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "ClickHouseAsyncMetrics_OSUserTimeNormalized{clickhouse_service=\"$service_id\"} + ClickHouseAsyncMetrics_OSSystemTimeNormalized{clickhouse_service=\"$service_id\"}",
+          "expr": "ClickHouseAsyncMetrics_CGroupUserTimeNormalized{clickhouse_service=\"$service_id\"} + ClickHouseAsyncMetrics_CGroupSystemTimeNormalized{clickhouse_service=\"$service_id\"}",
           "hide": false,
           "instant": false,
           "legendFormat": "{{instance}}",


### PR DESCRIPTION
- updated readme: added some description, link to the Grafana Dashboard Markeplace,  related blog post
- swap on the dashboard the following metrics (due to relevant changes in 25.8 - [issue](https://github.com/ClickHouse/ClickHouse/issues/76810)):
  - `OSUserTimeNormalized` -> `CGroupUserTimeNormalized`
  - `OSUserTimeNormalized` -> `CGroupSystemTimeNormalized`